### PR TITLE
[Doc] Fix a 🪦🔗

### DIFF
--- a/docs/getting_started/write.md
+++ b/docs/getting_started/write.md
@@ -113,7 +113,7 @@ val search_scenario = Scenario(title = "Search documents") {
 * The scenario title `Search documents` will be shown in the execution report.
 * There are 2 steps `When I visit a search engine` and `Then I am on the front page`
 * The first step will execute an HTTP GET call on the target name `search_engine` on the uri `/`
-    * It also has one [validation](/documentation/actions/introduction/#validation) `request accepted` to check the response code status is 200.
+    * It also has one [validation](/documentation/actions/#validation) `request accepted` to check the response code status is 200.
 * The second step does nothing meaningful in this example
 
 !!! tip "Et voilà !"


### PR DESCRIPTION
 - said link had been broken on commit 15d4856 while renaming `docs/actions/introduction.md` to `docs/documentation/actions/index.md`