### PR TITLE
[Doc] The getting started section navigation should be more intuitive

### DIFF
--- a/docs/documentation/write.md
+++ b/docs/documentation/write.md
@@ -1,0 +1,1 @@
+../getting_started/write.md

--- a/docs/getting_started/write.md
+++ b/docs/getting_started/write.md
@@ -118,4 +118,4 @@ val search_scenario = Scenario(title = "Search documents") {
 
 !!! tip "Et voilà !"
     You have successfully setup and written your first scenario using Chutney.  
-    Now, you will see how to run it ! :material-rocket-launch:
+    Now, you will see how to [run it ! :material-rocket-launch:](/getting_started/run "🏃")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
       - CI/CD integration:
           - synchronize: installation/ci_cd/scenario_sync.md
   - Documentation:
-      - Write a scenario: getting_started/write.md
+      - Write a scenario: documentation/write.md
       - Actions:
           - documentation/actions/index.md
           - AMQP: documentation/actions/amqp.md


### PR DESCRIPTION
## Rationale:

Previously, the sections `Getting Started > Write your first scenario` and `Documentation > Write a scenario` were pointing to the same file which made mkDoc have both served under the same context.

Therefore, people in the `Getting Started` were _warp jumped_ to `Documentation`, which was hella confusing for beginners (the type of people to go check a "getting started" thingy)

## The solution
Duplicating the file was not an option, but symlinks are. (turns out it is even what MkDocs do recommend cf [this issue](https://github.com/mkdocs/mkdocs/issues/1974#issuecomment-582423382))

## If you are affraid it might break on windows (because symlinks are weird and not supported on windows)

[No it won't](https://github.com/mkdocs/mkdocs/issues/1974#issuecomment-582438911 "says this stranger on the internets"), [no they're not](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links "windows has had them for quite a while now") ...