### PR TITLE
fix: Remove i18n option

### DIFF
--- a/docs/installation/on_premise/details.md
+++ b/docs/installation/on_premise/details.md
@@ -1,6 +1,6 @@
 # Database
 
-[Liquidbase](https://www.liquibase.org/){:target="_blank"} is used to manage Chutney RDBMS schema.  
+[Liquibase](https://www.liquibase.org/){:target="_blank"} is used to manage Chutney RDBMS schema.  
 You can find corresponding changelog [here](https://github.com/chutney-testing/chutney/blob/master/server/src/main/resources/changelog/db.changelog-master.xml){:target="_blank"}.
 
 !!! note

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,16 +97,6 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/chutney-testing
-  alternate:
-    - name: English
-      link: /en/
-      lang: en
-    - name: Français
-      link: /fr/
-      lang: fr
-    - name: 中文
-      link: /zh/
-      lang: zh
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
Now that we know we are not alone, I thought we could avoid a deceptive effect by removing the language selector.
And fix a thirsty typo !